### PR TITLE
Fix blockerList.json url-filter RE syntax

### DIFF
--- a/RediffBlock/blockerList.json
+++ b/RediffBlock/blockerList.json
@@ -1,6 +1,6 @@
 [{
   "trigger": {
-    "url-filter": "247realmedia.com",
+    "url-filter": "247realmedia\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -8,7 +8,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "2mdn.net",
+    "url-filter": "2mdn\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -16,7 +16,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "acxiom-online.com",
+    "url-filter": "acxiom-online\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -24,7 +24,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adadviser.net",
+    "url-filter": "adadviser\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -32,7 +32,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adblade.com",
+    "url-filter": "adblade\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -40,7 +40,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adkengage.com",
+    "url-filter": "adkengage\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -48,7 +48,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "admagnet.net",
+    "url-filter": "admagnet\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -56,7 +56,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adnxs.com",
+    "url-filter": "adnxs\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -64,7 +64,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adobetag.com",
+    "url-filter": "adobetag\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -72,7 +72,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adroll.com",
+    "url-filter": "adroll\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -80,7 +80,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adsonar.com",
+    "url-filter": "adsonar\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -88,7 +88,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adspeed.net",
+    "url-filter": "adspeed\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -96,7 +96,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adsymptotic.com",
+    "url-filter": "adsymptotic\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -104,7 +104,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adtechus.com",
+    "url-filter": "adtechus\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -112,7 +112,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "advertising.com",
+    "url-filter": "advertising\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -120,7 +120,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adzerk.net",
+    "url-filter": "adzerk\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -128,7 +128,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "afy11.net",
+    "url-filter": "afy11\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -136,7 +136,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "agilone.com",
+    "url-filter": "agilone\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -144,7 +144,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "amazon-adsystem.com",
+    "url-filter": "amazon-adsystem\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -152,7 +152,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "ads.yahoo.com",
+    "url-filter": "ads\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -160,7 +160,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adserver.yahoo.com",
+    "url-filter": "adserver\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -168,7 +168,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adsrvr.org",
+    "url-filter": "adsrvr\\.org/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -176,7 +176,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "adtech.de",
+    "url-filter": "adtech\\.de/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -184,7 +184,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "analytics.yahoo.com",
+    "url-filter": "analytics\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -192,7 +192,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "backbeatmedia.com",
+    "url-filter": "backbeatmedia\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -200,7 +200,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bc.yahoo.com",
+    "url-filter": "bc\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -208,7 +208,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bkrtx.com",
+    "url-filter": "bkrtx\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -216,7 +216,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "cxense.com",
+    "url-filter": "cxense\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -224,7 +224,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gemini.yahoo.com",
+    "url-filter": "gemini\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -232,7 +232,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "ysm.yahoo.com",
+    "url-filter": "ysm\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -240,7 +240,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "atdmt.com",
+    "url-filter": "atdmt\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -248,7 +248,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "atwola.com",
+    "url-filter": "atwola\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -256,7 +256,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "betrad.com",
+    "url-filter": "betrad\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -264,7 +264,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bizographics.com",
+    "url-filter": "bizographics\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -272,7 +272,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bizrate.com",
+    "url-filter": "bizrate\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -280,7 +280,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "blogads.com",
+    "url-filter": "blogads\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -288,7 +288,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bluekai.com",
+    "url-filter": "bluekai\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -296,7 +296,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "bounceexchange.com",
+    "url-filter": "bounceexchange\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -304,7 +304,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "brcdn.com",
+    "url-filter": "brcdn\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -312,7 +312,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "buysellads.com",
+    "url-filter": "buysellads\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -320,7 +320,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "captifymedia.com",
+    "url-filter": "captifymedia\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -328,7 +328,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "carbonads.net",
+    "url-filter": "carbonads\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -336,7 +336,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "casalemedia.com",
+    "url-filter": "casalemedia\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -344,7 +344,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "caspion.com",
+    "url-filter": "caspion\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -352,7 +352,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "chango.com",
+    "url-filter": "chango\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -360,7 +360,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "channeladvisor.com",
+    "url-filter": "channeladvisor\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -368,7 +368,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "chartbeat.com",
+    "url-filter": "chartbeat\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -376,7 +376,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "chartbeat.net",
+    "url-filter": "chartbeat\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -384,7 +384,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "chitika.net",
+    "url-filter": "chitika\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -392,7 +392,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "clicktale.net",
+    "url-filter": "clicktale\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -400,7 +400,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "collect.igodigital.com",
+    "url-filter": "collect\\.igodigital\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -408,7 +408,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "content.ad",
+    "url-filter": "content\\.ad/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -416,7 +416,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "convertro.com",
+    "url-filter": "convertro\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -424,7 +424,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "crazyegg.com",
+    "url-filter": "crazyegg\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -432,7 +432,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "criteo.com",
+    "url-filter": "criteo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -440,7 +440,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "criteo.net",
+    "url-filter": "criteo\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -448,7 +448,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "crsspxl.com",
+    "url-filter": "crsspxl\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -456,7 +456,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "crwdcntrl.net",
+    "url-filter": "crwdcntrl\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -464,7 +464,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "ct.buzzfeed.com",
+    "url-filter": "ct\\.buzzfeed\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -472,7 +472,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "demdex.net",
+    "url-filter": "demdex\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -480,7 +480,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "dmtry.com",
+    "url-filter": "dmtry\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -488,7 +488,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "dotomi.com",
+    "url-filter": "dotomi\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -496,7 +496,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "doubleclick.net",
+    "url-filter": "doubleclick\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -504,7 +504,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "doubleverify.com",
+    "url-filter": "doubleverify\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -512,7 +512,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "dwin1.com",
+    "url-filter": "dwin1\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -520,7 +520,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "dynamicyield.com",
+    "url-filter": "dynamicyield\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -528,7 +528,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "effectivemeasure.net",
+    "url-filter": "effectivemeasure\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -536,7 +536,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "eloqua.com",
+    "url-filter": "eloqua\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -544,7 +544,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "en25.com",
+    "url-filter": "en25\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -552,7 +552,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "eproof.com",
+    "url-filter": "eproof\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -560,7 +560,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "everestjs.net",
+    "url-filter": "everestjs\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -568,7 +568,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "everesttech.net",
+    "url-filter": "everesttech\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -576,7 +576,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "exelator.com",
+    "url-filter": "exelator\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -584,7 +584,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "exponential.com",
+    "url-filter": "exponential\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -592,7 +592,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "extole.com",
+    "url-filter": "extole\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -600,7 +600,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "fastclick.net",
+    "url-filter": "fastclick\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -608,7 +608,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "fetchback.com",
+    "url-filter": "fetchback\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -616,7 +616,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "flite.com",
+    "url-filter": "flite\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -624,7 +624,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "fmpub.net",
+    "url-filter": "fmpub\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -632,7 +632,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "ftjcfx.com",
+    "url-filter": "ftjcfx\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -640,7 +640,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "getclicky.com",
+    "url-filter": "getclicky\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -648,7 +648,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "getsidecar.com",
+    "url-filter": "getsidecar\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -656,7 +656,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "go-mpulse.net",
+    "url-filter": "go-mpulse\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -664,7 +664,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "google-analytics.com",
+    "url-filter": "google-analytics\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -672,7 +672,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "googleadservices.com",
+    "url-filter": "googleadservices\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -680,7 +680,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "googlesyndication.com",
+    "url-filter": "googlesyndication\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -688,7 +688,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "googletagmanager.com",
+    "url-filter": "googletagmanager\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -696,7 +696,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "googletagservices.com",
+    "url-filter": "googletagservices\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -704,7 +704,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gravity.com",
+    "url-filter": "gravity\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -712,7 +712,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "grvcdn.com",
+    "url-filter": "grvcdn\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -720,7 +720,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gscounters.eu1.gigya.com",
+    "url-filter": "gscounters\\.eu1\\.gigya\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -728,7 +728,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gscounters.gigya.com",
+    "url-filter": "gscounters\\.gigya\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -736,7 +736,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gscounters.us1.gigya.com",
+    "url-filter": "gscounters\\.us1\\.gigya\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -744,7 +744,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gumgum.com",
+    "url-filter": "gumgum\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -752,7 +752,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "himediads.com",
+    "url-filter": "himediads\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -760,7 +760,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "hit-counts.com",
+    "url-filter": "hit-counts\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -768,7 +768,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "hlserve.com",
+    "url-filter": "hlserve\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -776,7 +776,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "hotjar.com",
+    "url-filter": "hotjar\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -784,7 +784,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "hs-analytics.net",
+    "url-filter": "hs-analytics\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -792,7 +792,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "hubspot.com",
+    "url-filter": "hubspot\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -800,7 +800,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "images.taboola.com",
+    "url-filter": "images\\.taboola\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -808,7 +808,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "imrworldwide.com",
+    "url-filter": "imrworldwide\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -816,7 +816,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "inspectlet.com",
+    "url-filter": "inspectlet\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -824,7 +824,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "intellitxt.com",
+    "url-filter": "intellitxt\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -832,7 +832,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "intermarkets.net",
+    "url-filter": "intermarkets\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -840,7 +840,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "iperceptions.com",
+    "url-filter": "iperceptions\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -848,7 +848,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "kissmetrics.com",
+    "url-filter": "kissmetrics\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -856,7 +856,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "korrelate.net",
+    "url-filter": "korrelate\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -864,7 +864,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "krxd.net",
+    "url-filter": "krxd\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -872,7 +872,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "lexity.com",
+    "url-filter": "lexity\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -880,7 +880,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "lijit.com",
+    "url-filter": "lijit\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -888,7 +888,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "linkconnector.com",
+    "url-filter": "linkconnector\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -896,7 +896,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "linksynergy.com",
+    "url-filter": "linksynergy\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -904,7 +904,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "listrakbi.com",
+    "url-filter": "listrakbi\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -912,7 +912,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "madisonlogic.com",
+    "url-filter": "madisonlogic\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -920,7 +920,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "mathtag.com",
+    "url-filter": "mathtag\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -928,7 +928,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "maxymiser.net",
+    "url-filter": "maxymiser\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -936,7 +936,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "media.net",
+    "url-filter": "media\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -944,7 +944,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "media6degrees.com",
+    "url-filter": "media6degrees\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -952,7 +952,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "mediaforge.com",
+    "url-filter": "mediaforge\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -960,7 +960,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "mediaplex.com",
+    "url-filter": "mediaplex\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -968,7 +968,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "mercent.com",
+    "url-filter": "mercent\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -976,7 +976,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "moatads.com",
+    "url-filter": "moatads\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -984,7 +984,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "monetate.net",
+    "url-filter": "monetate\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -992,7 +992,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "monitus.net",
+    "url-filter": "monitus\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1000,7 +1000,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "mookie1.com",
+    "url-filter": "mookie1\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1008,7 +1008,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "msads.net",
+    "url-filter": "msads\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1016,7 +1016,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "neodatagroup.com",
+    "url-filter": "neodatagroup\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1024,7 +1024,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "netseer.com",
+    "url-filter": "netseer\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1032,7 +1032,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "netshelter.net",
+    "url-filter": "netshelter\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1040,7 +1040,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "newscred.com",
+    "url-filter": "newscred\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1048,7 +1048,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "nexac.com",
+    "url-filter": "nexac\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1056,7 +1056,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "omtrdc.net",
+    "url-filter": "omtrdc\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1064,7 +1064,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "opbandit.com",
+    "url-filter": "opbandit\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1072,7 +1072,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "outbrain.com",
+    "url-filter": "outbrain\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1080,7 +1080,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pagefair.com",
+    "url-filter": "pagefair\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1088,7 +1088,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pagefair.net",
+    "url-filter": "pagefair\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1096,7 +1096,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pardot.com",
+    "url-filter": "pardot\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1104,7 +1104,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "perfectaudience.com",
+    "url-filter": "perfectaudience\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1112,7 +1112,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pictela.net",
+    "url-filter": "pictela\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1120,7 +1120,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pixel.wp.com",
+    "url-filter": "pixel\\.wp\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1128,7 +1128,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pixel.yabidos.com",
+    "url-filter": "pixel\\.yabidos\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1136,7 +1136,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pointroll.com",
+    "url-filter": "pointroll\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1144,7 +1144,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "postrelease.com",
+    "url-filter": "postrelease\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1152,7 +1152,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pro-market.net",
+    "url-filter": "pro-market\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1160,7 +1160,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pulsemgr.com",
+    "url-filter": "pulsemgr\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1168,7 +1168,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "px.owneriq.net",
+    "url-filter": "px\\.owneriq\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1176,7 +1176,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "pzkysq.pink",
+    "url-filter": "pzkysq\\.pink/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1184,7 +1184,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "qualtrics.com",
+    "url-filter": "qualtrics\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1192,7 +1192,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "quantcast.com",
+    "url-filter": "quantcast\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1200,7 +1200,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "quantserve.com",
+    "url-filter": "quantserve\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1208,7 +1208,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "questionmarket.com",
+    "url-filter": "questionmarket\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1216,7 +1216,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "r7ls.net",
+    "url-filter": "r7ls\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1224,7 +1224,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "referrer.disqus.com",
+    "url-filter": "referrer\\.disqus\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1232,7 +1232,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "res-x.com",
+    "url-filter": "res-x\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1240,7 +1240,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "revsci.net",
+    "url-filter": "revsci\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1248,7 +1248,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "rlcdn.com",
+    "url-filter": "rlcdn\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1256,7 +1256,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "rubiconproject.com",
+    "url-filter": "rubiconproject\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1264,7 +1264,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "saymedia.com",
+    "url-filter": "saymedia\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1272,7 +1272,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "scorecardresearch.com",
+    "url-filter": "scorecardresearch\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1280,7 +1280,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "segment.io",
+    "url-filter": "segment\\.io/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1288,7 +1288,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "sellpoints.com",
+    "url-filter": "sellpoints\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1296,7 +1296,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "servebom.com",
+    "url-filter": "servebom\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1304,7 +1304,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "servedbyopenx.com",
+    "url-filter": "servedbyopenx\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1312,7 +1312,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "serving-sys.com",
+    "url-filter": "serving-sys\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1320,7 +1320,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "simplereach.com",
+    "url-filter": "simplereach\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1328,7 +1328,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "sitescout.com",
+    "url-filter": "sitescout\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1336,7 +1336,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "skimlinks.com",
+    "url-filter": "skimlinks\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1344,7 +1344,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "skimresources.com",
+    "url-filter": "skimresources\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1352,7 +1352,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "sonobi.com",
+    "url-filter": "sonobi\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1360,7 +1360,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "spotxchange.com",
+    "url-filter": "spotxchange\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1368,7 +1368,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "stats.wordpress.com",
+    "url-filter": "stats\\.wordpress\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1376,7 +1376,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "stats.wp.com",
+    "url-filter": "stats\\.wp\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1384,7 +1384,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "streamads.yahoo.com",
+    "url-filter": "streamads\\.yahoo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1392,7 +1392,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "sumome.com",
+    "url-filter": "sumome\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1400,7 +1400,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "taboola.com",
+    "url-filter": "taboola\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1408,7 +1408,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tacoda.net",
+    "url-filter": "tacoda\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1416,7 +1416,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tracker.neon-images.com",
+    "url-filter": "tracker\\.neon-images\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1424,7 +1424,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tracking.searchmarketing.com",
+    "url-filter": "tracking\\.searchmarketing\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1432,7 +1432,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tribalfusion.com",
+    "url-filter": "tribalfusion\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1440,7 +1440,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "trove.com",
+    "url-filter": "trove\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1448,7 +1448,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tru.am",
+    "url-filter": "tru\\.am/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1456,7 +1456,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "turn.com",
+    "url-filter": "turn\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1464,7 +1464,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "tynt.com",
+    "url-filter": "tynt\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1472,7 +1472,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "ugdturner.com",
+    "url-filter": "ugdturner\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1480,7 +1480,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "umbel.com",
+    "url-filter": "umbel\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1488,7 +1488,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "usabilla.com",
+    "url-filter": "usabilla\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1496,7 +1496,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "veinteractive.com",
+    "url-filter": "veinteractive\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1504,7 +1504,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "verticalscope.com",
+    "url-filter": "verticalscope\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1512,7 +1512,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "viglink.com",
+    "url-filter": "viglink\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1520,7 +1520,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "virool.com",
+    "url-filter": "virool\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1528,7 +1528,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "visualrevenue.com",
+    "url-filter": "visualrevenue\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1536,7 +1536,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "yieldmo.com",
+    "url-filter": "yieldmo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1544,7 +1544,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "yldbt.com",
+    "url-filter": "yldbt\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1552,7 +1552,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "zedo.com",
+    "url-filter": "zedo\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1560,7 +1560,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "zergnet.com",
+    "url-filter": "zergnet\\.com/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1568,7 +1568,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "zdbb.net",
+    "url-filter": "zdbb\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1576,7 +1576,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "zqtk.net",
+    "url-filter": "zqtk\\.net/",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1584,7 +1584,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "chartbeat.js",
+    "url-filter": "chartbeat\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1592,7 +1592,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "analytics.js",
+    "url-filter": "analytics\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1600,7 +1600,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "beacon.js",
+    "url-filter": "beacon\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1608,7 +1608,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "beacon.min.js",
+    "url-filter": "beacon\\.min\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1616,7 +1616,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "alllinksclicktracker.js",
+    "url-filter": "alllinksclicktracker\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1624,7 +1624,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "atrk.js",
+    "url-filter": "atrk\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1632,7 +1632,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "dtrack.js",
+    "url-filter": "dtrack\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1640,7 +1640,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gatracking.js",
+    "url-filter": "gatracking\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1648,7 +1648,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "gpt.js",
+    "url-filter": "gpt\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1656,7 +1656,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "kissmetrics.js",
+    "url-filter": "kissmetrics\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1664,7 +1664,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "omniture.js",
+    "url-filter": "omniture\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1672,7 +1672,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "sitecatalyst.js",
+    "url-filter": "sitecatalyst\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1680,7 +1680,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "twitter.com/widgets.js",
+    "url-filter": "twitter\\.com/widgets\\.js",
     "load-type" : ["third-party"]
   },
   "action": {
@@ -1688,7 +1688,7 @@
   }
 }, {
   "trigger": {
-    "url-filter": "usertracking_script.js",
+    "url-filter": "usertracking_script\\.js",
     "load-type" : ["third-party"]
   },
   "action": {


### PR DESCRIPTION
`url-filter` is a regular expression, so `.` must be escaped!

Moreover this field should really be: `^https?://([^/]+\\.)?example\\.com/`, but the leading wildcard `[^/]+` leads to a performance hit, so I elected to leave it out. Performance really requires fully-expanded host names, which would in turn make the number of entries much higher!
Note we can't use `^https?://example\\.com/` as a workaround since this would not match sub-domains.
Hence `example\\.com/`; could lead to a few false positives if a (bad) host name is in the URL, but this is quite rare in practice.
