### PR TITLE
Modified compatibility restriction description

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Allow `BlockParty` in Content Blockers under Settings → Safari.
 
 [“Note: Apps containing content blocking extensions for Safari on iOS are available only on 64-bit devices, due to performance limitations of 32-bit devices.”](https://developer.apple.com/library/prerelease/ios/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html)
 
-The exceptions to this are iPhone 5 and iPhone 5C which have been tested to be working with BlockParty.
+The 32-bit compatability restriction only applies to Content Blockers that are submitted to the App Store. If compiled from source and loaded from Xcode, BlockParty is competible with all iOS devices running iOS 9 and above. 
 
 ## References
 


### PR DESCRIPTION
The 32-bit compatability restriction only applies to Content Blockers that are submitted to the App Store. If compiled from source and loaded from Xcode, BlockParty is competible with all iOS devices running iOS 9 and above.
